### PR TITLE
Use  get-host-by-name() instead of get-host-by-addr()

### DIFF
--- a/univention_domain_join/utils/general.py
+++ b/univention_domain_join/utils/general.py
@@ -47,7 +47,7 @@ def execute_as_root(func):
 
 def name_is_resolvable(name):
 	try:
-		socket.gethostbyaddr(name)
+		socket.gethostbyname(name)
 		return True
 	except Exception:
 		return False


### PR DESCRIPTION
Try resolving host name instead of `gethostbyaddr`
For me this fixes joining a domain by CLI.