### PR TITLE
systemctl-resolve -> resolvectl

### DIFF
--- a/univention_domain_join/utils/domain.py
+++ b/univention_domain_join/utils/domain.py
@@ -91,7 +91,7 @@ def get_ucs_domainname_of_dns_server():
 
 
 def get_nameservers():
-	output = subprocess.check_output(['systemd-resolve', '--status'])
+	output = subprocess.check_output(['resolvectl', 'status'])
 
 	nameservers = set()
 	last_line_was_dns_servers_line = False

--- a/univention_domain_join/utils/general.py
+++ b/univention_domain_join/utils/general.py
@@ -47,7 +47,7 @@ def execute_as_root(func):
 
 def name_is_resolvable(name):
 	try:
-		socket.gethostbyaddr(name)
+		socket.gethostbyname(name)
 		return True
 	except Exception:
 		return False

--- a/univention_domain_join/utils/general.py
+++ b/univention_domain_join/utils/general.py
@@ -47,7 +47,7 @@ def execute_as_root(func):
 
 def name_is_resolvable(name):
 	try:
-		socket.gethostbyname(name)
+		socket.gethostbyaddr(name)
 		return True
 	except Exception:
 		return False


### PR DESCRIPTION
This fixes two issues that I had when trying this script with Ubuntu Jammy:

- systemctl-resolve is no longer available and got replaced by resolvectl
- `name_is_resolvable` takes a name as argument but called `socket.gethostbyaddr` (which expects an IP address instead) rather than `socket.gethostbyname`

Fixing these two things allowed me to run it like this:
`root:~# univention-domain-join-cli --username Administrator --domain paedml-linux.lokal --dc-ip 10.1.0.1`
(It wouldn't run without the domain or dc-ip parameters, but I assume that is primarily due to some local issues.)